### PR TITLE
feat: 新增 GenerateOpenApiDoc 支持 @Schema 注解

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@
 - 扩展set方法,返回this实例;方便链式调用
 - 增加只添加java注释
 - 兼容swagger3 且 可以生成全包名路径
+- 增加`GenerateOpenApiDoc`支持Open API的注解
+  - @ApiModel -> @Schema
+  - @ApiModelProperty(value="") -> @Schema(value="")
+  ```xml
+      <plugin type="mybatis.generator.plugins.GenerateOpenApiDoc">
+          <!-- 启用只生成 java 注释 -->
+          <property name="javaDoc" value="false"/>
+          <!-- 是否使用完整路径作为 Schema 的 description 值，默认为false，设置为true时为避免swagger $ref报错将路径名称中的.替换为了$-->
+          <property name="useFullPathName" value="false"/>
+      </plugin>
+  ```
 
 #### 1.快速使用
 ##### 1. maven 在buid节点中引入本插件, 如下示例

--- a/src/main/java/mybatis/generator/plugins/GenerateOpenApiDoc.java
+++ b/src/main/java/mybatis/generator/plugins/GenerateOpenApiDoc.java
@@ -1,0 +1,62 @@
+package mybatis.generator.plugins;
+
+import org.mybatis.generator.api.IntrospectedColumn;
+import org.mybatis.generator.api.IntrospectedTable;
+import org.mybatis.generator.api.PluginAdapter;
+import org.mybatis.generator.api.dom.java.Field;
+import org.mybatis.generator.api.dom.java.TopLevelClass;
+
+import java.util.List;
+
+/**
+ * @author tanshin
+ * date 2022/02/28
+ * description 根据数据库注释对实体类生成注解，扩展支持Open API，允许开启或者关闭注解生成
+ *
+ */
+public class GenerateOpenApiDoc extends PluginAdapter {
+    /**
+     * 替换Schema(description=xxx) value包含的.
+     */
+    public static final String SPLIT_CHAR = "$";
+
+    public boolean validate(List<String> list) {
+        return true;
+    }
+
+    @Override
+    public boolean modelFieldGenerated(Field field, TopLevelClass topLevelClass, IntrospectedColumn introspectedColumn, IntrospectedTable introspectedTable, ModelClassType modelClassType) {
+        /*
+           Schema的description值默认为实体类的简称；
+         */
+        String classAnnotation;
+        boolean useFullPathName = Boolean.parseBoolean(properties.getProperty("useFullPathName", "false"));
+        System.out.println(useFullPathName);
+        if (!useFullPathName) {
+            classAnnotation = "@Schema";
+        } else {
+            // 替换掉完整路径名称中的.为其他符号
+            String topLevelClassName = String.valueOf(topLevelClass.getType());
+            classAnnotation = "@Schema(description=\"" + topLevelClassName.replace(".", SPLIT_CHAR) + "\")";
+        }
+
+        if (!topLevelClass.getAnnotations().contains(classAnnotation)) {
+            topLevelClass.addAnnotation(classAnnotation);
+        }
+
+        String schemaAnnotationPackage = "io.swagger.v3.oas.annotations.media.Schema";
+
+        topLevelClass.addImportedType(schemaAnnotationPackage);
+
+        String apiJavaDoc = properties.getProperty("javaDoc", "false");
+        if("TRUE".equals(apiJavaDoc.toUpperCase())) {
+            field.addJavaDocLine("/**");
+            field.addJavaDocLine(introspectedColumn.getRemarks());
+            field.addJavaDocLine("*/");
+        }
+
+        // 去掉了实体类Java属性
+        field.addAnnotation("@Schema(description=\"" + introspectedColumn.getRemarks() + "\")");
+        return super.modelFieldGenerated(field, topLevelClass, introspectedColumn, introspectedTable, modelClassType);
+    }
+}


### PR DESCRIPTION
背景： 在Spring Boot 2.6之后的版本，使用 SpringFox 3.0 无法正常支持；

解决方案之一是迁移 SpringDoc。SpringDoc是基于OpenAPI 3，在SpringDoc官方迁移说明（https://springdoc.org/#migrating-from-springfox）里说明了SpringFox的对应注解迁移。
